### PR TITLE
Expose leaf node data

### DIFF
--- a/smt_test.go
+++ b/smt_test.go
@@ -630,8 +630,11 @@ func TestGetLeaf(t *testing.T) {
 		if err != nil {
 			t.Errorf("returned error when getting empty key: %v", err)
 		}
-		if leaf != nil {
-			t.Error("did not get nil when getting empty key")
+		if leaf.ValueHash != nil {
+			t.Error("did not get nil ValueHash when getting empty key")
+		}
+		if leaf.Path == nil {
+			t.Error("got nil Path when getting empty key")
 		}
 
 		_, err = smt.Update([]byte("testKey"), []byte("testValue"))


### PR DESCRIPTION
Expose leaf node data with a `GetLeaf()` method.

This will allow us to avoid an external hashing step, and use the hashed key (path) and value directly from within a Cosmos KV store.